### PR TITLE
Fix `post details not showing` error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
     title: `Nighty Night`,
     description: `Learning to talk to computers`,
     author: `@nightwarrior-xxx`,
+    pathPrefix: '/blog',
   },
   plugins: [
     `gatsby-plugin-react-helmet`,


### PR DESCRIPTION
added a pathprefix for your blog's static files. Now it should work just fine.